### PR TITLE
Disallow bypassing ban by using subdomains

### DIFF
--- a/src/discord.js
+++ b/src/discord.js
@@ -30,7 +30,7 @@ function initBot(){
         if (msg.content.toLowerCase().startsWith("!github")) {
             msg.channel.send('Linkki github organisaatioon:\n<https://koira.testausserveri.fi/github/join>');
         }
-        if (msg.content.includes("img.trimpsuz.xyz")) {
+        if (/.*\.trimpsuz.xyz/.exec(msg.content)) {
              msg.delete({timeout: 1000});
         }
     });

--- a/src/discord.js
+++ b/src/discord.js
@@ -30,7 +30,7 @@ function initBot(){
         if (msg.content.toLowerCase().startsWith("!github")) {
             msg.channel.send('Linkki github organisaatioon:\n<https://koira.testausserveri.fi/github/join>');
         }
-        if (/.*\.trimpsuz.xyz/.exec(msg.content)) {
+        if (/\S*\.trimpsuz\.xyz/i.test(msg.content)) {
              msg.delete({timeout: 1000});
         }
     });


### PR DESCRIPTION
This necessary feature had a vulnerability that I fixed, as it could been easily be bypassed by using an another subdomain!

Credit to this discord user for figuring the vulnerability, so I could quickly fix it before it being abused:
![Image of why](https://media.discordapp.net/attachments/883700459968294913/888055389327863879/unknown.png)