### PR TITLE
Remove embed from join Github organization message

### DIFF
--- a/src/api/router.js
+++ b/src/api/router.js
@@ -123,7 +123,7 @@ router.get('/authorized', async function (req, res) {
         }
     }))
     .then(() => discordClient.channels.fetch(config.discord.defaultChannel))
-    .then((channel) => channel.send(`${user.login} liittyi Testausserverin GitHub-organisaatioon 🎉! Liity sinäkin: https://koira.testausserveri.fi/github/join`))
+    .then((channel) => channel.send(`${user.login} liittyi Testausserverin GitHub-organisaatioon 🎉! Liity sinäkin: <https://koira.testausserveri.fi/github/join>`))
     .then(() => {
         res.redirect("https://github.com/Testausserveri");
     })


### PR DESCRIPTION
Just to make aula slightly more readable. The embed serves absolutely no purpose and takes up about a third of normal screen height in Discord.